### PR TITLE
Configure API deployment on Vercel

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,3 @@
+const app = require('../index');
+
+module.exports = app;

--- a/index.js
+++ b/index.js
@@ -39,9 +39,13 @@ app.get('/', (req, res) => {
   res.send('Bem-vindo à API!');
 });
 
-// Porta do servidor
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Servidor rodando em http://localhost:${PORT}`);
-  console.log(`Documentação disponível em http://localhost:${PORT}/api-docs`);
-});
+module.exports = app;
+
+if (process.env.VERCEL !== '1') {
+  // Porta do servidor
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Servidor rodando em http://localhost:${PORT}`);
+    console.log(`Documentação disponível em http://localhost:${PORT}/api-docs`);
+  });
+}

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,39 @@ Este projeto é uma API desenvolvida para ser consumida pelos seus testes automa
 Esta API está hospedada no Railway, com integração ao banco de dados PostgreSQL para facilitar o desenvolvimento e os testes automatizados.
 
 
+
+## Deploy no Vercel
+
+Este projeto já está pronto para deploy no Vercel com suporte à API Express em modo serverless.
+
+1. Instale a CLI do Vercel (opcional):
+   ```bash
+   npm i -g vercel
+   ```
+
+2. Faça login na sua conta:
+   ```bash
+   vercel login
+   ```
+
+3. No diretório do projeto, execute:
+   ```bash
+   vercel
+   ```
+
+4. Configure as variáveis de ambiente no painel do Vercel (Project > Settings > Environment Variables):
+   - `NODE_ENV=production`
+   - `DATABASE_URL`
+   - `JWT_SECRET`
+   - (se usar) demais variáveis `DB_PROD_*`
+
+5. Para publicar em produção:
+   ```bash
+   vercel --prod
+   ```
+
+Após o deploy, sua documentação continua disponível em `/api-docs`.
+
 ## Contribuição
 
 Sinta-se à vontade para abrir issues ou pull requests para melhorar este projeto.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "api/index.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "api/index.js"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Permitir que a API Express seja implantada no Vercel em modo serverless exportando o `app` e evitando chamar `listen` no ambiente do Vercel.
- Fornecer um entrypoint compatível com o runtime do Vercel e uma configuração de rota/build que direcione todo o tráfego para o handler serverless.

### Description
- Atualizei `index.js` para `module.exports = app` e adicionei uma condição para chamar `app.listen` somente quando `process.env.VERCEL !== '1'`.
- Adicionei `api/index.js` que importa e exporta o `app` para servir como entrypoint serverless do Vercel.
- Criei `vercel.json` com `@vercel/node` como build e uma rota catch-all para `api/index.js`.
- Atualizei `readme.md` incluindo instruções passo a passo de deploy no Vercel e variáveis de ambiente necessárias.

### Testing
- Executei `node -e "process.env.VERCEL='1'; const app=require('./index'); console.log(typeof app);"`, que carregou o `app` (imprime `function`) e exibiu um erro de conexão com PostgreSQL por não haver DB local, confirmando que o `app` é importável em modo Vercel.
- Verifiquei o estado do repositório com `git status --short`, adicionei os arquivos e confirmei o commit com `git add && git commit`, que foi bem-sucedido.
- Não há testes automatizados adicionais fornecidos neste PR; validação manual consistiu nos comandos acima e na inspeção das alterações de arquivos (`index.js`, `api/index.js`, `vercel.json`, `readme.md`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e336b981883208eac233ca8bd7bec)