### PR TITLE
Use default Swagger UI theme

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,3 @@
+const app = require('../index');
+
+module.exports = app;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const cors = require('cors'); // Importa o pacote cors
 const { swaggerUi, swaggerDocs } = require('./swagger');
 const usersRoutes = require('./routes/users');
 const usersInfoRoutes = require('./routes/userInfo');
-const path = require('path');
 const authRoutes = require('./routes/auth');  // Importando as rotas de autenticação
 
 const app = express();
@@ -19,12 +18,9 @@ app.use(cors({
   allowedHeaders: ['Content-Type', 'Authorization'], // Cabeçalhos permitidos
 }));
 
-app.use('/swagger-dark.css', express.static(path.join(__dirname, 'swagger-dark.css')));
 
 // Configuração do Swagger
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs, {
-  customCssUrl: '/swagger-dark.css',
-}));
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 
 // Rotas de autenticação
 app.use('/api', authRoutes);
@@ -39,9 +35,13 @@ app.get('/', (req, res) => {
   res.send('Bem-vindo à API!');
 });
 
-// Porta do servidor
-const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log(`Servidor rodando em http://localhost:${PORT}`);
-  console.log(`Documentação disponível em http://localhost:${PORT}/api-docs`);
-});
+module.exports = app;
+
+if (process.env.VERCEL !== '1') {
+  // Porta do servidor
+  const PORT = process.env.PORT || 3000;
+  app.listen(PORT, () => {
+    console.log(`Servidor rodando em http://localhost:${PORT}`);
+    console.log(`Documentação disponível em http://localhost:${PORT}/api-docs`);
+  });
+}

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,39 @@ Este projeto é uma API desenvolvida para ser consumida pelos seus testes automa
 Esta API está hospedada no Railway, com integração ao banco de dados PostgreSQL para facilitar o desenvolvimento e os testes automatizados.
 
 
+
+## Deploy no Vercel
+
+Este projeto já está pronto para deploy no Vercel com suporte à API Express em modo serverless.
+
+1. Instale a CLI do Vercel (opcional):
+   ```bash
+   npm i -g vercel
+   ```
+
+2. Faça login na sua conta:
+   ```bash
+   vercel login
+   ```
+
+3. No diretório do projeto, execute:
+   ```bash
+   vercel
+   ```
+
+4. Configure as variáveis de ambiente no painel do Vercel (Project > Settings > Environment Variables):
+   - `NODE_ENV=production`
+   - `DATABASE_URL`
+   - `JWT_SECRET`
+   - (se usar) demais variáveis `DB_PROD_*`
+
+5. Para publicar em produção:
+   ```bash
+   vercel --prod
+   ```
+
+Após o deploy, sua documentação continua disponível em `/api-docs`.
+
 ## Contribuição
 
 Sinta-se à vontade para abrir issues ou pull requests para melhorar este projeto.

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "api/index.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "api/index.js"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- The Swagger UI at `/api-docs` rendered a black/blank page in the Vercel deployment, likely due to serving a custom `swagger-dark.css` stylesheet from the serverless environment.
- Reverting to the default `swagger-ui-express` theme removes the custom static asset dependency and reduces the chance of asset-loading issues on Vercel.

### Description
- Removed the `path` import and the static route that served `swagger-dark.css` from `index.js` so the app no longer exposes a custom CSS file.
- Reverted the Swagger setup to the default call `swaggerUi.setup(swaggerDocs)` without `customCssUrl` so the standard theme/assets are used.
- Ensured the Express `app` is exported with `module.exports = app` and that `app.listen` is only invoked when `process.env.VERCEL !== '1'` (serverless-compatible entrypoint kept).
- Kept the Vercel entry (`api/index.js`), `vercel.json` and README deployment instructions intact to preserve serverless deploy behavior.

### Testing
- Launched the app locally and requested `/api-docs/` with `curl`, receiving an HTTP `200` and HTML which contains the default `swagger-ui.css` and `swagger-ui-bundle.js`, indicating the default UI assets are being served successfully.
- Verified that starting the server logs the usual PostgreSQL connection error locally when no DB is present, which is unrelated to the Swagger rendering issue.
- Committed the change with `git commit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e336b981883208eac233ca8bd7bec)